### PR TITLE
Fix valid values causing program to exit.

### DIFF
--- a/wizconfig.py
+++ b/wizconfig.py
@@ -502,7 +502,7 @@ def main():
                 logger.info("mac_addr:", len(mac_addr), mac_addr)
                 mac_addr = "00:08:DC:" + mac_addr
 
-            if wiz752cmdObj.isvalidparameter("MC", mac_addr) is not False:
+            if not wiz752cmdObj.isvalidparameter("MC", mac_addr):
                 logger.info("Invalid Mac address!\r\n")
                 sys.exit(0)
 
@@ -521,7 +521,7 @@ def main():
         setcmd_cmd = list(setcmd.keys())
         for i in range(len(setcmd)):
             # logger.info('%r , %r' % (setcmd_cmd[i], setcmd.get(setcmd_cmd[i])))
-            if wiz752cmdObj.isvalidparameter(setcmd_cmd[i], setcmd.get(setcmd_cmd[i])) is not False:
+            if not wiz752cmdObj.isvalidparameter(setcmd_cmd[i], setcmd.get(setcmd_cmd[i])):
                 logger.info(f"{'#' * 25}\nInvalid parameter: {setcmd.get(setcmd_cmd[i])} \nPlease refer to {sys.argv[0]} -h\r\n")
                 sys.exit(0)
 
@@ -540,7 +540,7 @@ def main():
             if args.multiset:
                 host_ip = args.multiset
                 # logger.info('Host ip: %s\n' % host_ip)
-                if wiz752cmdObj.isvalidparameter("LI", host_ip) is not False:
+                if not wiz752cmdObj.isvalidparameter("LI", host_ip):
                     logger.info("Invalid IP address!\r\n")
                     sys.exit(0)
 


### PR DESCRIPTION
The code in version 1.2.0 and before was "== False" then it was changed to "is not False" which is the opposite boolean check. This causes that valid parameters are treated as invalid and no options can be used except for search.